### PR TITLE
Add is_script_like inherent method to Destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 *
 
+# 0.3.0
+
+* Add `Destination::is_script_like`
+
 # 0.2.0
 
 * Remove quickcheck (apparently, it was forcing everybody to download it, even if they didn't need it)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "content-security-policy"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Michael Howell <michael@notriddle.com>"]
 description = "Will parse and validate Content-Security-Policy level 3"
 keywords = ["http", "csp", "security"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use `content-security-policy`, add it to your project's `Cargo.toml` file:
 
 ```toml
 [dependencies]
-content-security-policy = "0.2.0"
+content-security-policy = "0.3.0"
 ```
 
 # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ use regex::Regex;
 extern crate lazy_static;
 #[macro_use]
 extern crate bitflags;
+#[cfg(feature = "serde")]
+extern crate serde;
 
 pub mod text_util;
 pub mod sandboxing_directive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,6 +343,16 @@ pub enum Destination {
     Xslt,
 }
 
+impl Destination {
+    pub fn is_script_like(self) -> bool {
+        use Destination::*;
+        match self {
+            AudioWorklet | PaintWorklet | Script | ServiceWorker | SharedWorker | Worker | Xslt => true,
+            _ => false
+        }
+    }
+}
+
 /**
 response to be validated
 */
@@ -925,11 +935,7 @@ fn script_directives_postrequest_check(request: &Request, response: &Response, d
 }
 
 fn request_is_script_like(request: &Request) -> bool {
-    use Destination::*;
-    match request.destination {
-        AudioWorklet | PaintWorklet | Script | ServiceWorker | SharedWorker | Worker | Xslt => true,
-        _ => false
-    }
+    request.destination.is_script_like()
 }
 
 fn should_fetch_directive_execute(effective_directive_name: &str, directive_name: &str, policy: &Policy) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub mod text_util;
 pub mod sandboxing_directive;
 
 pub use url::{Origin, Url};
-#[cfg(feature = "quickcheck")] use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")] use serde::{Deserialize, Serialize};
 use std::borrow::{Borrow, Cow};
 use std::fmt::{self, Display, Formatter};
 use text_util::{
@@ -319,7 +319,7 @@ pub enum Initiator {
     None,
 }
 
-#[cfg_attr(feature = "quickcheck", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Destination {
     None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ fn scheme_is_httpx(scheme: &str) -> bool {
 A single parsed content security policy
 */
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Policy {
     pub directive_set: Vec<Directive>,
     pub disposition: PolicyDisposition,
@@ -142,6 +143,7 @@ impl Policy {
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct CspList(pub Vec<Policy>);
 
 impl Display for CspList {
@@ -313,6 +315,7 @@ pub enum ParserMetadata {
     None,
 }
 
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Initiator {
     Prefetch,
@@ -384,30 +387,35 @@ pub enum ViolationResource {
 
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum CheckResult {
     Allowed,
     Blocked,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Violates {
     DoesNotViolate,
     Directive(Directive),
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum PolicyDisposition {
     Enforce,
     Report,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum PolicySource {
     Header,
     Meta,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Directive {
     name: String,
     value: Vec<String>,


### PR DESCRIPTION
Matches up more closely to how Servo's `Destination` enum works