### PR TITLE
Don't include : in the port comparison.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1268,7 +1268,8 @@ fn does_url_match_expression_in_origin_with_redirect_count(
             // It should not be possible to match HOST_SOURCE_GRAMMAR without having a host part
             return DoesNotMatch;
         }
-        let port_part = captures.name("port").map(|port| port.as_str()).unwrap_or("");
+        // Skip the first byte of the port capture to avoid the `:`.
+        let port_part = captures.name("port").map(|port| &port.as_str()[1..]).unwrap_or("");
         let url_port = url_port(url);
         if port_part_match(port_part, &url_port[..], url.scheme()) != Matches {
             return DoesNotMatch;

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -25,6 +25,12 @@ macro_rules! test_should_request_be_blocked {
 
 // all tests should have a name starting with pre_request_
 test_should_request_be_blocked!{
+    (   name: pre_request_wild_connect_port_allow,
+        url: "https://www.notriddle.com:443/meta",
+        origin: "https://example.com",
+        policy: "connect-src https://*.notriddle.com:443",
+        dest: None,
+        result: Allowed),
     (   name: pre_request_wild_script_allow,
         url: "https://www.notriddle.com/script.js",
         origin: "https://www.notriddle.com",


### PR DESCRIPTION
This fixes an unexpected CSP error loading hubs.mozilla.org in Servo.