### PR TITLE
Exclude lockfile from Cargo package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "content-security-policy"
-version = "0.6.0"
+version = "0.5.4"
 dependencies = [
  "base64",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/rust-ammonia/rust-content-security-policy"
 edition = "2018"
 rust-version = "1.71.1"
 exclude = [
+  "Cargo.lock",
   "Cargo.nix",
   "default.nix",
   "nix/",


### PR DESCRIPTION
We want it in the repository so that CI doesn't implicitly bump packages, but Cargo doesn't actually uses it, so it doesn't need to be there.