### PR TITLE
Enable Deserialize, Serialize for SandboxingFlagSet when enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,9 +432,13 @@ pub enum ParserMetadata {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Initiator {
+    Download,
+    ImageSet,
+    Manifest,
     Prefetch,
     Prerender,
     Fetch,
+    Xslt,
     None,
 }
 
@@ -1194,14 +1198,14 @@ fn get_the_effective_directive_for_request(request: &Request) -> &'static str {
         return "default-src";
     }
     match request.destination {
-        Manifest => "manifest-src",
+        Destination::Manifest => "manifest-src",
         Object | Embed => "object-src",
         Frame | IFrame => "frame-src",
         Audio | Track | Video => "media-src",
         Font => "font-src",
         Image => "img-src",
         Style => "style-src-elem",
-        Script | Xslt | AudioWorklet | PaintWorklet => "script-src-elem",
+        Script | Destination::Xslt | AudioWorklet | PaintWorklet => "script-src-elem",
         ServiceWorker | SharedWorker | Worker => "worker-src",
         Json | WebIdentity => "connect-src",
         Report => "",

--- a/src/sandboxing_directive.rs
+++ b/src/sandboxing_directive.rs
@@ -1,7 +1,9 @@
+#[cfg(feature = "serde")] use serde::{Deserialize, Serialize};
 use bitflags::bitflags;
 
 bitflags!{
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
     pub struct SandboxingFlagSet: u32 {
         const SANDBOXED_NAVIGATION_BROWSING_CONTEXT_FLAG = 0x00000001;
         const SANDBOXED_AUXILIARY_NAVIGATION_BROWSING_CONTEXT_FLAG = 0x00000002;
@@ -21,6 +23,7 @@ bitflags!{
         const SANDBOXED_MODALS_FLAG = 0x00002000;
         const SANDBOXED_ORIENTATION_LOCK_BROWSING_CONTEXT_FLAG = 0x00004000;
         const SANDBOXED_PRESENTATION_BROWSING_CONTEXT_FLAG = 0x00008000;
+        const SANDBOXED_DOWNLOADS_BROWSING_CONTEXT_FLAG = 0x0010000;
     }
 }
 
@@ -28,6 +31,7 @@ pub fn parse_a_sandboxing_directive(tokens: &[String]) -> SandboxingFlagSet {
     let mut output = SandboxingFlagSet::all();
     for token in tokens {
         let remove = match &token[..] {
+            "allow-downloads" => SandboxingFlagSet::SANDBOXED_DOWNLOADS_BROWSING_CONTEXT_FLAG,
             "allow-popups" =>
                 SandboxingFlagSet::SANDBOXED_AUXILIARY_NAVIGATION_BROWSING_CONTEXT_FLAG,
             "allow-top-navigation" =>

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -99,6 +99,8 @@ fn sandbox_document_flags() {
     assert_eq!(Some(SandboxingFlagSet::all() ^ SandboxingFlagSet::SANDBOXED_AUXILIARY_NAVIGATION_BROWSING_CONTEXT_FLAG), policy.get_sandboxing_flag_set_for_document());
     let policy = CspList::parse("sandbox allow-forms", PolicySource::Header, PolicyDisposition::Enforce);
     assert_eq!(Some(SandboxingFlagSet::all() ^ SandboxingFlagSet::SANDBOXED_FORMS_BROWSING_CONTEXT_FLAG), policy.get_sandboxing_flag_set_for_document());
+    let policy = CspList::parse("sandbox allow-downloads", PolicySource::Header, PolicyDisposition::Enforce);
+    assert_eq!(Some(SandboxingFlagSet::all() ^ SandboxingFlagSet::SANDBOXED_DOWNLOADS_BROWSING_CONTEXT_FLAG), policy.get_sandboxing_flag_set_for_document());
     let policy = CspList::parse("sandbox; connect-src https://*.notriddle.com:443", PolicySource::Header, PolicyDisposition::Enforce);
     assert_eq!(Some(SandboxingFlagSet::all()), policy.get_sandboxing_flag_set_for_document());
     let policy = CspList::parse("sandbox allow-popups; connect-src https://*.notriddle.com:443", PolicySource::Header, PolicyDisposition::Enforce);


### PR DESCRIPTION
Also updates `Initiator` and adds the "[allow-downloads](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/sandbox#allow-downloads)" directive.

Thank you 👍 